### PR TITLE
Don't check for authenticated user

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -88,8 +88,12 @@ const KiteAPI = {
   },
 
   authenticateSessionID(key) {
+    // Unlike authenticateUser above, this method does not check to see if a
+    // user is already authenticated before trying to authenticate. This
+    // method is only used in specialized flows, so we're special-casing it
+    // here.
     checkArguments(this.authenticateSessionID, key);
-    return this.canAuthenticateUser()
+    return KiteConnector.isKiteReachable()
     .then(() => this.request({
       path: '/api/account/authenticate',
       method: 'POST',


### PR DESCRIPTION
Allows the `kite-installer` flow to complete when a user is already logged in