### PR TITLE
Onboarding file endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,16 @@ KiteAPI.getSupportedLanguages().then(languages => {
 })
 ```
 
+#### .getOnboardingFilePath()
+
+Makes a request to the onboarding_file endpoint and returns a promise that resolves with a filepath string.
+
+```js
+KiteAPI.getOnboardingFilePath().then(path => {
+  // do something with path
+})
+```
+
 #### .getHoverDataAtPosition(filename, source, position, editor)
 #### .getReportDataAtPosition(filename, source, position, editor)
 #### .getSymbolReportDataForId(id)

--- a/README.md
+++ b/README.md
@@ -83,6 +83,24 @@ KiteAPI.requestJSON({path}).then(data => {
 })
 ```
 
+#### .setKiteSetting(key, value)
+
+Makes a `POST` request to Kite at the endpoint `/clientapi/settings/${key}`, where the body is set to `value`. It automatically parses the JSON response when the status code is `200`
+
+```js
+KiteAPI.setKiteSetting('some_setting_name', 'a_value')
+```
+
+#### .getKiteSetting(key)
+
+Makes a `GET` request to Kite at the endpoint `/clientapi/settings/${key}`. It automatically parses the JSON response when the status code is `200`
+
+```js
+KiteAPI.getKiteSetting('some_setting').then(settingValue => {
+  // do something with settingValue
+})
+```
+
 #### .canAuthenticateUser()
 
 Returns a promise that resolves if a user can be authenticated. A user can be authenticated if Kite is reachable and if the user is not already logged into Kite.

--- a/lib/index.js
+++ b/lib/index.js
@@ -71,6 +71,20 @@ const KiteAPI = {
     .then(data => JSON.parse(data));
   },
 
+  setKiteSetting(key, value) {
+    return this.requestJSON({
+      path: `/clientapi/settings/${key}`,
+      method: 'POST',
+    }, JSON.stringify(value))
+  },
+
+  getKiteSetting(key) {
+    return this.requestJSON({
+      path: `/clientapi/settings/${key}`,
+      method: 'GET'
+    })
+  },
+
   canAuthenticateUser() {
     return KiteConnector.isKiteReachable()
     .then(() => utils.reversePromise(

--- a/lib/index.js
+++ b/lib/index.js
@@ -174,6 +174,12 @@ const KiteAPI = {
     });
   },
 
+  getOnboardingFilePath() {
+    return this.requestJSON({
+      path: '/clientapi/plugins/onboarding_file',
+    });
+  },
+
   getHoverDataAtPosition(filename, source, position, editor) {
     checkArguments(this.getHoverDataAtPosition, filename, source, position);
     const path = urls.hoverPath(filename, source, position, editor);

--- a/lib/index.js
+++ b/lib/index.js
@@ -75,14 +75,14 @@ const KiteAPI = {
     return this.requestJSON({
       path: `/clientapi/settings/${key}`,
       method: 'POST',
-    }, JSON.stringify(value))
+    }, JSON.stringify(value));
   },
 
   getKiteSetting(key) {
     return this.requestJSON({
       path: `/clientapi/settings/${key}`,
-      method: 'GET'
-    })
+      method: 'GET',
+    });
   },
 
   canAuthenticateUser() {

--- a/test/kite-api.test.js
+++ b/test/kite-api.test.js
@@ -365,6 +365,20 @@ describe('KiteAPI', () => {
       });
     });
 
+    describe('.getOnboardingFilePath()', () => {
+      withKiteRoutes([[
+        o => o.path === '/clientapi/plugins/onboarding_file',
+        o => fakeResponse(200, JSON.stringify('/path/to/onboarding_file.py')),
+      ]]);
+
+      it('returns a promise that resolves with an onboarding file path', () => {
+        return waitsForPromise(() => KiteAPI.getOnboardingFilePath())
+        .then(path => {
+          expect(path).to.equal('/path/to/onboarding_file.py');
+        });
+      });
+    });
+
     describe('.getHoverDataAtPosition()', () => {
       const source = loadFixture('sources/json-dump.py');
       const filename = '/path/to/json-dump.py';


### PR DESCRIPTION
Pending this: https://github.com/kiteco/kiteco/pull/6656

An endpoint for an interactive onboarding tutorial

Also adds `getKiteSetting` and `setKiteSetting` helpers for easy querying and setting of `clientapi/settings/...` stuff