### PR TITLE
major version bump; linux update

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -291,6 +291,7 @@ const KiteAPI = {
     return {
       darwin: 'macos',
       win32: 'windows',
+      linux: 'linux',
     }[os.platform()];
   },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kite-api",
-  "version": "2.14.0",
+  "version": "3.0.0",
   "description": "API methods to access Kite",
   "main": "lib/index.js",
   "repository": {
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "md5": "^2.2.0",
-    "kite-connector": "^2.8.0"
+    "kite-connector": "git://github.com/kiteco/kite-connect-js.git#linux-compatibility"
   },
   "devDependencies": {
     "babel-eslint": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "md5": "^2.2.0",
-    "kite-connector": "git://github.com/kiteco/kite-connect-js.git#linux-compatibility"
+    "kite-connector": "^3.0.0"
   },
   "devDependencies": {
     "babel-eslint": "^7.1.1",


### PR DESCRIPTION
updates for linux compatibility

made this a major version bump due to the significance of the change. We should do the initial publish manually when it comes time for that.

Will need to update once [this](https://github.com/kiteco/kite-connect-js/pull/21) is merged