### PR TITLE
adds ksg endpoints

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -269,9 +269,9 @@ const KiteAPI = {
       .catch(() => {});
   },
 
-  getKSGCodeBlocks(query) {
-    checkArguments(this.getKSGCodeBlocks, query);
-    return this.requestJSON({ path: `/clientapi/ksg/codeblocks?query=${encodeURIComponent(query)}` })
+  getKSGCodeBlocks(query, results = 3) {
+    checkArguments(this.getKSGCodeBlocks, query, results);
+    return this.requestJSON({ path: `/clientapi/ksg/codeblocks?query=${encodeURIComponent(query)}&results=${results}` })
       .catch(() => {});
   },
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -263,6 +263,18 @@ const KiteAPI = {
     .catch(() => {});
   },
 
+  getKSGCompletions(query) {
+    checkArguments(this.getKSGCompletions, query);
+    return this.requestJSON({ path: `/clientapi/ksg/completions?query=${encodeURIComponent(query)}` })
+      .catch(() => {});
+  },
+
+  getKSGCodeBlocks(query) {
+    checkArguments(this.getKSGCodeBlocks, query);
+    return this.requestJSON({ path: `/clientapi/ksg/codeblocks?query=${encodeURIComponent(query)}` })
+      .catch(() => {});
+  },
+
   getAutocorrectData(filename, source, editorMeta) {
     checkArguments(this.getAutocorrectData, filename, source, editorMeta);
 

--- a/test/fixtures/responses/ksg-codeblocks.json
+++ b/test/fixtures/responses/ksg-codeblocks.json
@@ -1,0 +1,79 @@
+{
+  "query": "python http get",
+  "answers": [
+      {
+          "answer_id": 54856660,
+          "code_blocks": [
+              "urllib3",
+              "import urllib3\n\npool_manager = urllib3.PoolManager()\n",
+              "example_request = pool_manager.request(\"GET\", \"https://example.com\")\n\nprint(example_request.data.decode(\"utf-8\")) # Response text.\nprint(example_request.status) # Status code.\nprint(example_request.headers[\"Content-Type\"]) # Content type.\n",
+              "example_request = pool_manager.request(\"GET\", \"https://example.com\", headers = {\n    \"Header1\": \"value1\",\n    \"Header2\": \"value2\"\n})\n"
+          ]
+      },
+      {
+          "answer_id": 15869929,
+          "code_blocks": [
+              "import requests\nr = requests.get(\"http://example.com/foo/bar\")\n",
+              ">>> print(r.status_code)\n>>> print(r.headers)\n>>> print(r.content)\n"
+          ]
+      },
+      {
+          "answer_id": 52351509,
+          "code_blocks": [
+              "import urllib.request\ncontents = urllib.request.urlopen(urllib.request.Request(\n    \"https://api.github.com/repos/cirosantilli/linux-kernel-module-cheat/releases/latest\",\n    headers={\"Accept\" : 'application/vnd.github.full+json\"text/html'}\n)).read()\nprint(contents)\n",
+              "import urllib2\ncontents = urllib2.urlopen(urllib2.Request(\n    \"https://api.github.com\",\n    headers={\"Accept\" : 'application/vnd.github.full+json\"text/html'}\n)).read()\nprint(contents)\n"
+          ]
+      },
+      {
+          "answer_id": 646213,
+          "code_blocks": [
+              "import httplib2\nresp, content = httplib2.Http().request(\"http://example.com/foo/bar\")\n"
+          ]
+      },
+      {
+          "answer_id": 645318,
+          "code_blocks": [
+              "import urllib2\ncontents = urllib2.urlopen(\"http://example.com/foo/bar\").read()\n",
+              "import urllib.request\ncontents = urllib.request.urlopen(\"http://example.com/foo/bar\").read()\n"
+          ]
+      },
+      {
+          "answer_id": 48050751,
+          "code_blocks": [
+              "try:\n    import urllib2 as urlreq # Python 2.x\nexcept:\n    import urllib.request as urlreq # Python 3.x\nreq = urlreq.Request(\"http://example.com/foo/bar\")\nreq.add_header('User-Agent', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36')\nurlreq.urlopen(req).read()\n",
+              "urllib2.HTTPError: HTTP Error 403: Forbidden",
+              "urllib.error.HTTPError: HTTP Error 403: Forbidden"
+          ]
+      },
+      {
+          "answer_id": 646159,
+          "code_blocks": [
+              "import httplib2\n\nresp, content = httplib2.Http().request(\"http://example.com/foo/bar\")\n"
+          ]
+      },
+      {
+          "answer_id": 31029124,
+          "code_blocks": [
+              "import sys, urllib.request\n\ndef reporthook(a, b, c):\n    print (\"% 3.1f%% of %d bytes\\r\" % (min(100, float(a * b) / c * 100), c))\n    sys.stdout.flush()\nfor url in sys.argv[1:]:\n    i = url.rfind(\"/\")\n    file = url[i+1:]\n    print (url, \"->\", file)\n    urllib.request.urlretrieve(url, file, reporthook)\nprint\n"
+          ]
+      },
+      {
+          "answer_id": 23813181,
+          "code_blocks": [
+              "from nap.url import Url\napi = Url('https://api.github.com')\n\ngists = api.join('gists')\nresponse = gists.get(params={'since': '2014-05-01T00:00:00Z'})\nprint(response.json())\n"
+          ]
+      },
+      {
+          "answer_id": 2003547,
+          "code_blocks": [
+              "import sys, urllib\n\ndef reporthook(a, b, c):\n    print \"% 3.1f%% of %d bytes\\r\" % (min(100, float(a * b) / c * 100), c),\n    sys.stdout.flush()\nfor url in sys.argv[1:]:\n    i = url.rfind(\"/\")\n    file = url[i+1:]\n    print url, \"->\", file\n    urllib.urlretrieve(url, file, reporthook)\nprint\n"
+          ]
+      },
+      {
+          "answer_id": 646229,
+          "code_blocks": [
+              "# From python cookbook, 2nd edition, page 487\nimport sys, urllib\n\ndef reporthook(a, b, c):\n    print \"% 3.1f%% of %d bytes\\r\" % (min(100, float(a * b) / c * 100), c),\nfor url in sys.argv[1:]:\n    i = url.rfind(\"/\")\n    file = url[i+1:]\n    print url, \"->\", file\n    urllib.urlretrieve(url, file, reporthook)\nprint\n"
+          ]
+      }
+  ]
+}

--- a/test/fixtures/responses/ksg-completions.json
+++ b/test/fixtures/responses/ksg-completions.json
@@ -1,0 +1,13 @@
+{
+  "query": "json",
+  "completions": [
+      "json formatter",
+      "jsonlint",
+      "jsonline",
+      "json parser",
+      "json file",
+      "json viewer",
+      "json validator",
+      "json editor"
+  ]
+}

--- a/test/kite-api.test.js
+++ b/test/kite-api.test.js
@@ -724,7 +724,7 @@ describe('KiteAPI', () => {
 
       describe('when there is a KSG Code Block response to be returned by kited', () => {
         withKiteRoutes([[
-          o => o.path === '/clientapi/ksg/codeblocks?query=fake',
+          o => o.path === '/clientapi/ksg/codeblocks?query=fake&results=3',
           o => fakeResponse(200, loadFixture('responses/ksg-codeblocks.json')), //TODO: need to create fixture
         ]]);
 
@@ -738,7 +738,7 @@ describe('KiteAPI', () => {
 
       describe('when an error status is returned by kited', () => {
         withKiteRoutes([[
-          o => o.path === '/clientapi/ksg/codeblocks?query=fake',
+          o => o.path === '/clientapi/ksg/codeblocks?query=fake&results=3',
           o => fakeResponse(404),
         ]]);
 

--- a/test/kite-api.test.js
+++ b/test/kite-api.test.js
@@ -689,6 +689,68 @@ describe('KiteAPI', () => {
       });
     });
 
+    describe('.getKSGCompletions()', () => {
+
+      describe('when there is a KSG completions response to be returned by kited', () => {
+        withKiteRoutes([[
+          o => o.path === '/clientapi/ksg/completions?query=fake',
+          o => fakeResponse(200, loadFixture('responses/ksg-completions.json')), //TODO: need to create fixture
+        ]]);
+
+        it('returns a promise that resolves with KSG completions', () => {
+          return waitsForPromise(() => KiteAPI.getKSGCompletions('fake'))
+          .then(completions => {
+            expect(completions).not.to.be(undefined);
+          });
+        });
+      });
+
+      describe('when an error status is returned by kited', () => {
+        withKiteRoutes([[
+          o => o.path === '/clientapi/ksg/completions?query=fake',
+          o => fakeResponse(404),
+        ]]);
+
+        it('returns a promise that resolves with undefined', () => {
+          return waitsForPromise(() => KiteAPI.getKSGCompletions('fake'))
+          .then(completions => {
+            expect(completions).to.be(undefined);
+          });
+        });
+      });
+    });
+
+    describe('.getKSGCodeBlocks()', () => {
+
+      describe('when there is a KSG Code Block response to be returned by kited', () => {
+        withKiteRoutes([[
+          o => o.path === '/clientapi/ksg/codeblocks?query=fake',
+          o => fakeResponse(200, loadFixture('responses/ksg-codeblocks.json')), //TODO: need to create fixture
+        ]]);
+
+        it('returns a promise that resolves with KSG Code Blocks', () => {
+          return waitsForPromise(() => KiteAPI.getKSGCodeBlocks('fake'))
+          .then(completions => {
+            expect(completions).not.to.be(undefined);
+          });
+        });
+      });
+
+      describe('when an error status is returned by kited', () => {
+        withKiteRoutes([[
+          o => o.path === '/clientapi/ksg/codeblocks?query=fake',
+          o => fakeResponse(404),
+        ]]);
+
+        it('returns a promise that resolves with undefined', () => {
+          return waitsForPromise(() => KiteAPI.getKSGCodeBlocks('fake'))
+          .then(completions => {
+            expect(completions).to.be(undefined);
+          });
+        });
+      });
+    });
+
     describe('.getAutocorrectData()', () => {
       const source = loadFixture('sources/errored.py');
       const filename = '/path/to/errored.py';


### PR DESCRIPTION
adds endpoints and tests for the KSG experiment

to test more e2e for the methods written, I ran the below with a `lib/test.js` file (e.g. `node ./lib/test.js`)
```
const KiteAPI = require('./index')

KiteAPI.getKSGCodeBlocks('python requests get').then(resp => console.log('code blocks resp', resp))

KiteAPI.getKSGCompletions('python requests').then(resp => console.log('completions resp', resp))
```