### PR TITLE
Pass in editor ID to onboarding_file endpoint

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -65,10 +65,10 @@ const KiteAPI = {
     });
   },
 
-  getOnboardingFilePath() {
-    return this.requestJSON({
-      path: '/clientapi/plugins/onboarding_file',
-    });
+  getOnboardingFilePath(editor, language = 'python') {
+    checkArguments(this.getOnboardingFilePath, editor, language);
+    const path = urls.onboardingFilePath(editor, language);
+    return this.requestJSON({path});
   },
 
   canAuthenticateUser() {

--- a/lib/url-helpers.js
+++ b/lib/url-helpers.js
@@ -2,6 +2,15 @@
 
 const md5 = require('md5');
 
+function onboardingFilePath(editor, language) {
+  return [
+    '/clientapi/plugins/onboarding_file', [
+      `editor=${editor}`,
+      `language=${language}`,
+    ].join('&'),
+  ].join('?');
+}
+
 function hoverPath(filename, source, position, editor, encoding) {
   const state = md5(source);
   const buffer = cleanPath(filename);
@@ -54,6 +63,7 @@ function cleanPath(p) {
 
 module.exports = {
   cleanPath,
+  onboardingFilePath,
   hoverPath,
   membersPath,
   projectDirPath,

--- a/test/kite-api.test.js
+++ b/test/kite-api.test.js
@@ -90,13 +90,18 @@ describe('KiteAPI', () => {
     });
 
     describe('.getOnboardingFilePath()', () => {
+      const editor = 'editor';
+      hasMandatoryArguments((args) => KiteAPI.getOnboardingFilePath(...args), [
+        editor,
+      ]);
+
       withKiteRoutes([[
-        o => o.path === '/clientapi/plugins/onboarding_file',
+        o => /^\/clientapi\/plugins\/onboarding_file\?editor=editor&language=python/.test(o.path),
         o => fakeResponse(200, JSON.stringify('/path/to/onboarding_file.py')),
       ]]);
 
       it('returns a promise that resolves with an onboarding file path', () => {
-        return waitsForPromise(() => KiteAPI.getOnboardingFilePath())
+        return waitsForPromise(() => KiteAPI.getOnboardingFilePath(editor))
         .then(path => {
           expect(path).to.equal('/path/to/onboarding_file.py');
         });


### PR DESCRIPTION
Changes for `getOnboardingFilePath` Atom and VSCode middleware for https://github.com/kiteco/kiteco/issues/8035